### PR TITLE
Updated snippets to support testing on local versions of AT framework.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "js-yaml": "2.1.0",
         "request": "2.27.0",
         "highlight.js": "7.3.0",
-        "humanize": "0.0.8"
+        "humanize": "0.0.8",
+        "optimist": "0.6.0"
     }
 }

--- a/routes/code.js
+++ b/routes/code.js
@@ -17,7 +17,8 @@ var codeHighlighter = function(app) {
       prod = mode == 'production',
       cache = app.get('cache'),
       logger = app.get('logger'),
-      port = app.get('port');
+      port = app.get('port'),
+      documentationPath = app.get('documentationPath');
 
   function middleware(req, res) {
     var key = req.url,
@@ -33,7 +34,7 @@ var codeHighlighter = function(app) {
       branch = file.split("/")[1];
       file = file.split("/").slice(2).join("/");
     }
-    if (prod) {
+    if (!documentationPath) {
       url = "https://raw.github.com/" + username + "/" + repo + "/" + branch + "/" + file;
     } else {
       url = "http://localhost:" + port + "/documentation_code/" + file;
@@ -55,7 +56,7 @@ var codeHighlighter = function(app) {
     function handleImagesPath(text, user, repo, branch, file) {
       var path = file.split("/"), image_url;
       path.pop();
-      if (prod) {
+      if (!documentationPath) {
         image_url = "http://raw.github.com/" + user + "/" + repo + "/" + branch + "/" + path.join("/");
       } else {
         image_url = "http://localhost:" + port + "/documentation_code/" + path.join("/");

--- a/routes/samples.js
+++ b/routes/samples.js
@@ -11,7 +11,8 @@ var sampleReader = function(app) {
       prod = mode == 'production',
       cache = app.get('cache'),
       logger = app.get('logger'),
-      port = app.get('port');
+      port = app.get('port'),
+      documentationPath = app.get('documentationPath');    
 
   var request_options = {
     method: "GET",
@@ -34,11 +35,11 @@ var sampleReader = function(app) {
     if (folder.indexOf("tree/") === 0) {
       branch = folder.split("/")[1];
       folder = folder.split("/").slice(2).join("/");
-    }
+    }      
 
-    if (prod) {
+    if (!documentationPath) {     
       url = "https://raw.github.com/" + user + "/" + repo + "/" + branch + "/" + folder + "/sample.yml";
-    } else {
+    } else {      
       url = "http://localhost:" + port + "/documentation_code/" + folder + "/sample.yml";
     }
 

--- a/routes/snippets.js
+++ b/routes/snippets.js
@@ -19,7 +19,8 @@ var snippetBuilder = function(app) {
       prod = mode == 'production',
       cache = app.get('cache'),
       logger = app.get('logger'),
-      port = app.get('port');
+      port = app.get('port'),
+      documentationPath = app.get('documentationPath');
 
   function middleware(req, res) {
 
@@ -38,7 +39,7 @@ var snippetBuilder = function(app) {
       file = file.split("/").slice(2).join("/");
     }
 
-    if (prod) {
+    if (!documentationPath) {
       url = "https://raw.github.com/" + username + "/" + repo + "/" + branch + "/" + file;
     } else {
       url = "http://localhost:" + port + "/documentation_code/" + file;

--- a/server.js
+++ b/server.js
@@ -3,15 +3,24 @@ var fs = require('fs');
 var http = require('http');
 var path = require('path');
 var hljs = require('highlight.js');
-
 var version = require('./package').version;
-
 var snippets = require('./routes/snippets');
 var samples = require('./routes/samples');
 var code = require('./routes/code');
-
 var Cache = require('./cache');
 var port = 3000;
+
+// Node library for option parsing: https://github.com/substack/node-optimist
+// To change the path of either samples or framework: node server.js --dp path/to/samples --fp path/to/framework
+var argv = require('optimist')  
+  .alias('dp', 'documentationPath')  
+  .alias('fp', 'frameworkPath')  
+  .alias('fv', 'frameworkVersion')    
+  .default('fv', 'latest')    
+  .alias('ff', 'frameworkFileName')
+  .default('ff', 'ariatemplates-%version%.js')    
+  .usage('Usage: $0 -dp [string] -fp [string] -fv [string] -ff [string]')  
+  .argv;
 
 // Custom AT syntax file
 hljs.LANGUAGES['at'] = require('./highlight.at.js')(hljs);
@@ -21,41 +30,25 @@ var app = express();
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'jade');
 app.set('version', version);
-
 app.set('port', port);
-
+app.set('documentationPath', argv.documentationPath);
+app.set('frameworkPath', argv.frameworkPath);
+app.set('frameworkVersion', argv.frameworkVersion);
+app.set('frameworkFileName', argv.frameworkFileName);
 
 app.use(function(req, res, next) {
   res.locals.host = (req.secure ? "https://" : "http://") + (req.header('x-forwarded-host') ? req.header('x-forwarded-host') : req.headers.host);
-  res.locals.atversion = req.query.atversion || "1.4.13";
+  res.locals.atversion = req.query.atversion;
   next();
 });
 app.use(express["static"](__dirname + '/public'));
 app.use(app.router);
 
-app.configure('development', function() {
-  var documentation_path = process.argv[2];
-  if (documentation_path) {
-    var doc_path_normalized = path.normalize(documentation_path);
-    var exists = fs.existsSync(doc_path_normalized);
-
-    if (exists) {
-      console.log('[Info] Documentation folder found at ' + doc_path_normalized);
-      app.set('logger', function() {
-        console.log.apply(console, arguments);
-      });
-
-      app.use('/documentation_code', express.static(doc_path_normalized));
-    } else {
-      console.log('[Error] No documentation folder found at ' + doc_path_normalized);
-      process.exit(1);
-    }
-
-    app.set('cache', { get : function () { return false; } });
-  } else {
-    console.log('[Error] You need to specify the documentation-code folder path');
-    process.exit(1);
-  }
+app.configure('development', function() {  
+  app.set('cache', { get : function () { return false; } });  
+  app.set('logger', function() {
+    console.log.apply(console, arguments);
+  });
 });
 
 app.configure('production', function() {
@@ -83,7 +76,30 @@ app.get('/snippets/github.com/:user/:repo/:file([/\\-._a-zA-Z0-9]+.[a-zA-Z]+)', 
 app.get('/samples/github.com/:user/:repo/:folder([/\\-_a-zA-Z0-9]+)', samples(app));
 app.get('/code/github.com/:user/:repo/:file([/\\-._a-zA-Z0-9]+.[a-zA-Z]+)', code(app));
 
+var serveDirectory = function (url, commandLinePath, pathName) {
+  var normalizedPath = path.normalize(commandLinePath);
+  var pathExists = fs.existsSync(commandLinePath);
+  if (pathExists) {      
+    console.log('[Info] %s found at %s.',pathName, normalizedPath);
+    app.use(url, express.static(normalizedPath));
+  } else {
+    console.log('[Error] %s NOT found at %s.', pathName, normalizedPath);
+    process.exit(1);
+  }
+};
 
+if (argv.documentationPath) {
+  serveDirectory("/documentation_code", argv.documentationPath, "documentation folder");
+}
+
+if (argv.frameworkPath) {
+  serveDirectory("/", argv.frameworkPath, "framework folder");
+  var frameworkFile = path.join(argv.frameworkPath, 'aria', argv.frameworkFileName.replace("%version%", argv.frameworkVersion));
+  if (!fs.existsSync(frameworkFile)) {
+    console.log('[Error] Framework main file NOT found at %s.', frameworkFile);
+    process.exit(1);
+  }
+}
 
 var server = http.createServer(app);
 server.listen(port, function() {

--- a/views/viewer.jade
+++ b/views/viewer.jade
@@ -6,12 +6,12 @@ html
     link(href='http://ariatemplates.com/styles/snippets/style.css', rel='stylesheet')
     link(href='http://ariatemplates.com/styles/snippets/highlight_skin.css', rel='stylesheet')
 
-    if (settings.env == 'production')
-      script(type='text/javascript', src='/aria/ariatemplates-#{atversion}.js')
-      script(type='text/javascript', src='/aria/css/atskin-#{atversion}.js')
+    if (atversion || !settings.frameworkPath)      
+      script(type='text/javascript', src='http://cdn.ariatemplates.com/at#{atversion || settings.frameworkVersion}.js?skin')
     else
-      script(type='text/javascript', src='http://cdn.ariatemplates.com/at#{atversion}.js?skin')
-
+      script(type='text/javascript', src='/aria/#{settings.frameworkFileName.replace("%version%", settings.frameworkVersion)}')
+      script(type='text/javascript', src='/aria/css/atskin-#{settings.frameworkVersion}.js')
+    
     script(type='text/javascript').
       aria.core.AppEnvironment.setEnvironment({
         defaultWidgetLibs: {


### PR DESCRIPTION
**_In_** order to test and fix samples, or even to create new samples for features in the AT framework that haven't been released yet, it is necessary to be able to run the server using a local version of the AT framework...  

**_Also_** included in this update, there is now the addition of optimist to pass in named arguments for the documentationPath, frameworkPath, frameworkVersion, frameworkFileName...

**_And_** it is also now possible to run the server without any arguments passed in, this defaults to the CDN for the framework (latest version) and GitHub for the samples.

<h6>Redirecting AT framework:</h6>

open source local unminified:
    <code>--fp ../at_simonarbuckle/build/target/bootstrap</code>
    <code>--fv 1.4.14</code>

open source local minified:
    <code>--fp ../at_simonarbuckle/build/target/production</code>
    <code>--fv 1.4.14</code>

Redirecting the framework (unminified) and samples locally:
<code>node server.js --fp ../at_simonarbuckle/build/target/bootstrap --fv 1.4.14 --dp ../documentation-code</code>

**_Note:_** even if you run the server redirecting the framework locally, you can still override this by adding <code>?atversion=1.4.14</code> to the browser URL and reloading the page, then the framework will be requested from the CDN using the AT version you specified.
