### PR TITLE
Updated snippets to support changing the skin using a url parameter.

### DIFF
--- a/server.js
+++ b/server.js
@@ -39,6 +39,7 @@ app.set('frameworkFileName', argv.frameworkFileName);
 app.use(function(req, res, next) {
   res.locals.host = (req.secure ? "https://" : "http://") + (req.header('x-forwarded-host') ? req.header('x-forwarded-host') : req.headers.host);
   res.locals.atversion = req.query.atversion;
+  res.locals.skin = req.query.skin;
   next();
 });
 app.use(express["static"](__dirname + '/public'));

--- a/views/viewer.jade
+++ b/views/viewer.jade
@@ -5,12 +5,14 @@ html
     link(href='http://ariatemplates.com/styles/webfonts.css', rel='stylesheet')
     link(href='http://ariatemplates.com/styles/snippets/style.css', rel='stylesheet')
     link(href='http://ariatemplates.com/styles/snippets/highlight_skin.css', rel='stylesheet')
-
-    if (atversion || !settings.frameworkPath)      
-      script(type='text/javascript', src='http://cdn.ariatemplates.com/at#{atversion || settings.frameworkVersion}.js?skin')
+            
+    if (atversion || !settings.frameworkPath) 
+      skinVersion = (skin === 'flatskin' || skin === 'atflatskin') ? 'flatskin' : 'skin'
+      script(type='text/javascript', src='http://cdn.ariatemplates.com/at#{atversion || settings.frameworkVersion}.js?#{skinVersion}')
     else
+      skinVersion = (skin) ? skin : "atskin-" + settings.frameworkVersion
       script(type='text/javascript', src='/aria/#{settings.frameworkFileName.replace("%version%", settings.frameworkVersion)}')
-      script(type='text/javascript', src='/aria/css/atskin-#{settings.frameworkVersion}.js')
+      script(type='text/javascript', src='/aria/css/#{skinVersion}.js')
     
     script(type='text/javascript').
       aria.core.AppEnvironment.setEnvironment({


### PR DESCRIPTION
With this update it will now be possible to use a url parameter to switch the skin.  Simply adding <code>?skin=atflatskin</code> to the url and then refreshing will change the skin from the default one to the <code>atflatskin</code>.  The skin parameter contains the skin filename so it can be used to change the skin to any skin you like when using it locally.

When using the CDN, you can still set <code>?skin=atflatskin</code> for the flat skin, or you can also use <code>?skin=flatskin</code>.
