### PR TITLE
(fix) one https url to githubusercontent was missing 

### DIFF
--- a/routes/code.js
+++ b/routes/code.js
@@ -56,7 +56,7 @@ var codeHighlighter = function(app) {
       var path = file.split("/"), image_url;
       path.pop();
       if (prod) {
-        image_url = "http://raw.githubusercontent.com/" + user + "/" + repo + "/" + branch + "/" + path.join("/");
+        image_url = "https://raw.githubusercontent.com/" + user + "/" + repo + "/" + branch + "/" + path.join("/");
       } else {
         image_url = "http://localhost:" + port + "/documentation_code/" + path.join("/");
       }


### PR DESCRIPTION
When building urls for images replacement (for images pointing to a github located one) we were missing one `https` 
