### PR TITLE
(feat) new query paramater ?wai to activate wai-aria support

### DIFF
--- a/routes/samples.js
+++ b/routes/samples.js
@@ -63,7 +63,8 @@ var sampleReader = function(app) {
         'title': yaml.title,
         'yaml': JSON.stringify(yaml),
         'rootmap': rootmap,
-        'sample_folder': sample_folder
+        'sample_folder': sample_folder,
+        'wai_aria': ["", "1", "true"].indexOf(query.wai) !== -1
       };
     }
 

--- a/views/viewer.jade
+++ b/views/viewer.jade
@@ -23,6 +23,9 @@ html
 
     script(type='text/javascript').
       aria.core.AppEnvironment.setEnvironment({
+        appSettings: {
+          waiAria: #{wai_aria}
+        },
         defaultWidgetLibs: {
           aria: "aria.widgets.AriaLib",
           html: "aria.html.HtmlLibrary"


### PR DESCRIPTION
Simply add `?wai` to the url to activate waiAria support.
The recognized patterns are `wai` or `wai=true` or `wai=1`. Anything else will not activate it.
